### PR TITLE
refactor security groups

### DIFF
--- a/bastion.cfhighlander.rb
+++ b/bastion.cfhighlander.rb
@@ -22,7 +22,7 @@ CfhighlanderTemplate do
     end
 
     ComponentParam 'VPCId', type: 'AWS::EC2::VPC::Id'
-    ComponentParam 'SecurityGroupDev', type: 'AWS::EC2::SecurityGroup::Id'
-    ComponentParam 'SecurityGroupOps', type: 'AWS::EC2::SecurityGroup::Id'
+    ComponentParam 'SecurityGroupDev'
+    ComponentParam 'SecurityGroupOps'
   end
 end

--- a/bastion.cfndsl.rb
+++ b/bastion.cfndsl.rb
@@ -5,24 +5,7 @@ CloudFormation do
   EC2_SecurityGroup('SecurityGroupBastion') do
     GroupDescription FnJoin(' ', [ Ref('EnvironmentName'), component_name ])
     VpcId Ref('VPCId')
-  end
-
-  EC2_SecurityGroupIngress('OpsIngressRule') do
-    Description 'SSH access from ops security group'
-    IpProtocol 'tcp'
-    FromPort '22'
-    ToPort '22'
-    GroupId FnGetAtt('SecurityGroupBastion','GroupId')
-    SourceSecurityGroupId Ref('SecurityGroupOps')
-  end
-
-  EC2_SecurityGroupIngress('DevIngressRule') do
-    Description 'SSH access from dev security group'
-    IpProtocol 'tcp'
-    FromPort '22'
-    ToPort '22'
-    GroupId FnGetAtt('SecurityGroupBastion','GroupId')
-    SourceSecurityGroupId Ref('SecurityGroupDev')
+    SecurityGroupIngress sg_create_rules(securityGroups, ip_blocks) if defined? securityGroups
   end
 
   EIP('BastionIPAddress') do
@@ -65,7 +48,7 @@ CloudFormation do
       "#!/bin/bash\n",
       "aws --region ", Ref("AWS::Region"), " ec2 associate-address --allocation-id ", FnGetAtt('BastionIPAddress','AllocationId') ," --instance-id $(curl http://169.254.169.254/2014-11-05/meta-data/instance-id -s)\n",
       "hostname ", Ref('EnvironmentName') ,"-" ,"bastion-`/opt/aws/bin/ec2-metadata --instance-id|/usr/bin/awk '{print $2}'`\n",
-      "sed '/HOSTNAME/d' /etc/sysconfig/network > /tmp/network && mv -f /tmp/network /etc/sysconfig/network && echo \"HOSTNAME=", Ref('EnvironmentName') ,"-" ,"bastion-`/opt/aws/bin/ec2-metadata --instance-id|/usr/bin/awk '{print $2}'`\" >>/etc/sysconfig/network && /etc/init.d/network restart\n",      
+      "sed '/HOSTNAME/d' /etc/sysconfig/network > /tmp/network && mv -f /tmp/network /etc/sysconfig/network && echo \"HOSTNAME=", Ref('EnvironmentName') ,"-" ,"bastion-`/opt/aws/bin/ec2-metadata --instance-id|/usr/bin/awk '{print $2}'`\" >>/etc/sysconfig/network && /etc/init.d/network restart\n",
     ]))
   end
 

--- a/bastion.config.yaml
+++ b/bastion.config.yaml
@@ -1,1 +1,16 @@
 maximum_availability_zones: 5
+
+# Set `ip_blocks` here or export from vpc component
+# ip_blocks:
+#   local:
+#     - 127.0.0.1/32
+#
+# securityGroups:
+#   -
+#     rules:
+#       -
+#         IpProtocol: tcp
+#         FromPort: 22
+#         ToPort: 22
+#     ips:
+#       - local


### PR DESCRIPTION
Applying a security group id as a source won't inherit the rules from that security group. Therefore we must specify the public IP's for the required port for external access to the bastion.