### PR TITLE
Updated instances tags and userdata

### DIFF
--- a/bastion.cfndsl.rb
+++ b/bastion.cfndsl.rb
@@ -44,13 +44,15 @@ CloudFormation do
     IamInstanceProfile Ref('InstanceProfile')
     KeyName Ref('KeyName')
     SecurityGroups [ Ref('SecurityGroupBastion') ]
-    extra_userdata = [] unless defined?(extra_userdata)
+    unless defined?(extra_userdata)
+      extra_userdata=[]
+    end
     UserData FnBase64(FnJoin("",[
       "#!/bin/bash\n",
       "aws --region ", Ref("AWS::Region"), " ec2 associate-address --allocation-id ", FnGetAtt('BastionIPAddress','AllocationId') ," --instance-id $(curl http://169.254.169.254/2014-11-05/meta-data/instance-id -s)\n",
       "hostname ", Ref('EnvironmentName') ,"-" ,"bastion-`/opt/aws/bin/ec2-metadata --instance-id|/usr/bin/awk '{print $2}'`\n",
       "sed '/HOSTNAME/d' /etc/sysconfig/network > /tmp/network && mv -f /tmp/network /etc/sysconfig/network && echo \"HOSTNAME=", Ref('EnvironmentName') ,"-" ,"bastion-`/opt/aws/bin/ec2-metadata --instance-id|/usr/bin/awk '{print $2}'`\" >>/etc/sysconfig/network && /etc/init.d/network restart\n",
-      FnJoin("",extra_userdata)
+      FnJoin("", extra_userdata)
     ]))
   end
 

--- a/bastion.cfndsl.rb
+++ b/bastion.cfndsl.rb
@@ -72,6 +72,7 @@ CloudFormation do
     instanceTags["Name"] = FnJoin("",[Ref('EnvironmentName'), "-bastion-xx"])
     instanceTags["Environment"] = Ref('EnvironmentName')
     instanceTags["EnvironmentType"] =  Ref('EnvironmentType')
+    instanceTags["Role"] =  "bastion"
 
     tags.each do |key,value|
       instanceTags[key] = value

--- a/bastion.cfndsl.rb
+++ b/bastion.cfndsl.rb
@@ -44,11 +44,13 @@ CloudFormation do
     IamInstanceProfile Ref('InstanceProfile')
     KeyName Ref('KeyName')
     SecurityGroups [ Ref('SecurityGroupBastion') ]
+    extra_userdata = [] unless defined?(extra_userdata)
     UserData FnBase64(FnJoin("",[
       "#!/bin/bash\n",
       "aws --region ", Ref("AWS::Region"), " ec2 associate-address --allocation-id ", FnGetAtt('BastionIPAddress','AllocationId') ," --instance-id $(curl http://169.254.169.254/2014-11-05/meta-data/instance-id -s)\n",
       "hostname ", Ref('EnvironmentName') ,"-" ,"bastion-`/opt/aws/bin/ec2-metadata --instance-id|/usr/bin/awk '{print $2}'`\n",
       "sed '/HOSTNAME/d' /etc/sysconfig/network > /tmp/network && mv -f /tmp/network /etc/sysconfig/network && echo \"HOSTNAME=", Ref('EnvironmentName') ,"-" ,"bastion-`/opt/aws/bin/ec2-metadata --instance-id|/usr/bin/awk '{print $2}'`\" >>/etc/sysconfig/network && /etc/init.d/network restart\n",
+      FnJoin("",extra_userdata)
     ]))
   end
 

--- a/bastion.cfndsl.rb
+++ b/bastion.cfndsl.rb
@@ -65,10 +65,20 @@ CloudFormation do
     MinSize 1
     MaxSize 1
     VPCZoneIdentifier az_conditional_resources('SubnetPublic', maximum_availability_zones)
-    addTag("Name", FnJoin("",[Ref('EnvironmentName'), "-bastion-xx"]), true)
-    addTag("Environment",Ref('EnvironmentName'), true)
-    addTag("EnvironmentType", Ref('EnvironmentType'), true)
-    addTag("Role", "bastion", true)
+
+    instanceTags = {}
+    instanceTags["Name"] = FnJoin("",[Ref('EnvironmentName'), "-bastion-xx"])
+    instanceTags["Environment"] = Ref('EnvironmentName')
+    instanceTags["EnvironmentType"] =  Ref('EnvironmentType')
+
+    tags.each do |key,value|
+      instanceTags[key] = value
+    end if tags.any?
+
+    instanceTags.each do |key,value|
+      addTag(key, value, true)
+    end
+
   end
 
   Output('SecurityGroupBastion', Ref('SecurityGroupBastion'))

--- a/bastion.config.yaml
+++ b/bastion.config.yaml
@@ -19,4 +19,5 @@ maximum_availability_zones: 5
 #   SSMParameters: true
 #   Role: 'runtime-cookbook::bastion'
 #
-#
+# extra_userdata:
+#   - "/opt/base2/bin/ec2-bootstrap\n"

--- a/bastion.config.yaml
+++ b/bastion.config.yaml
@@ -14,3 +14,9 @@ maximum_availability_zones: 5
 #         ToPort: 22
 #     ips:
 #       - local
+#
+# tags:
+#   SSMParameters: true
+#   Role: 'runtime-cookbook::bastion'
+#
+#


### PR DESCRIPTION
Added ability for overwriting default tags and creating additional tags
Added ability to append extra userdata to default userdata.
Note: cfndsl removes duplicates from extra_userdata list when loading from config yaml, adding extra spaces to duplicates will make them unique and get around this for now.