### PR TITLE
Enable inlined cloudformation rendering 

### DIFF
--- a/bastion.cfhighlander.rb
+++ b/bastion.cfhighlander.rb
@@ -1,5 +1,5 @@
 CfhighlanderTemplate do
-  DependsOn 'vpc@1.2.0'
+  DependsOn stdext
   Parameters do
     ComponentParam 'EnvironmentName', 'dev', isGlobal: true
     ComponentParam 'EnvironmentType', 'development', isGlobal: true
@@ -19,10 +19,14 @@ CfhighlanderTemplate do
 
     maximum_availability_zones.times do |az|
       ComponentParam "SubnetPublic#{az}"
+      MappingParam "Az#{az}" do
+          map 'AzMappings'
+          attribute "Az#{az}"
+      end
     end
 
     ComponentParam 'VPCId', type: 'AWS::EC2::VPC::Id'
-    ComponentParam 'SecurityGroupDev'
-    ComponentParam 'SecurityGroupOps'
+    ComponentParam 'SecurityGroupDev', type: 'AWS::EC2::SecurityGroup::Id'
+    ComponentParam 'SecurityGroupOps', type: 'AWS::EC2::SecurityGroup::Id'
   end
 end

--- a/bastion.cfhighlander.rb
+++ b/bastion.cfhighlander.rb
@@ -4,6 +4,8 @@ CfhighlanderTemplate do
     ComponentParam 'EnvironmentName', 'dev', isGlobal: true
     ComponentParam 'EnvironmentType', 'development', isGlobal: true
     ComponentParam 'Ami', type: 'AWS::EC2::Image::Id'
+    ComponentParam 'HostedZoneId'
+
     MappingParam('InstanceType') do
       map 'EnvironmentType'
       attribute 'BastionInstanceType'

--- a/bastion.cfndsl.rb
+++ b/bastion.cfndsl.rb
@@ -16,13 +16,13 @@ CloudFormation do
 
   Route53_RecordSet('BastionDNS') do
     Condition 'Route53ZoneGiven'
-    HostedZoneName FnJoin('', [ Ref('EnvironmentName'), '.', Ref('DnsDomain'), '.'])
+    HostedZoneName FnSub(dns_zone)
     Comment 'Bastion Public Record Set'
-    Name FnJoin('', [ "bastion", ".", Ref('EnvironmentName'), '.', Ref('DnsDomain'), '.' ])
+    Name FnSub(dns_record)
     Type 'A'
     TTL 60
     ResourceRecords [ Ref("BastionIPAddress") ]
-  end
+  end unless (dns_record.nil? or dns_record.empty?)
 
   IAM_Role('Role') do
     AssumeRolePolicyDocument service_role_assume_policy('ec2')

--- a/bastion.cfndsl.rb
+++ b/bastion.cfndsl.rb
@@ -16,7 +16,7 @@ CloudFormation do
 
   Route53_RecordSet('BastionDNS') do
     Condition 'Route53ZoneGiven'
-    HostedZoneName FnSub(dns_zone)
+    HostedZoneId Ref('HostedZoneId')
     Comment 'Bastion Public Record Set'
     Name FnSub(dns_record)
     Type 'A'

--- a/bastion.config.yaml
+++ b/bastion.config.yaml
@@ -1,3 +1,4 @@
+stdext: github:toshke/hl-component-stdext
 maximum_availability_zones: 5
 
 # Set `ip_blocks` here or export from vpc component

--- a/bastion.config.yaml
+++ b/bastion.config.yaml
@@ -1,6 +1,9 @@
 stdext: github:toshke/hl-component-stdext
-maximum_availability_zones: 5
 
+dns_record: bastion.$EnvironmentName.$DnsDomain
+dns_zone: $EnvironmentName.$DnsDomain
+
+maximum_availability_zones: 5
 # Set `ip_blocks` here or export from vpc component
 # ip_blocks:
 #   local:


### PR DESCRIPTION
# DO NOT MERGE UNTIL REFERENCE TO STDEXT IS RESOLVED 

## Improvements

### EC2 Key is optional

Access to EC2 bastion instance can be allowed through UserData, not only through KeyPair. This PR allows configuration with no key pair set. 

### AZ Condition
Conditions for AZs are depending on AZs rather than on resources themselves. This enables bastion component to be rendered in-line, not as a substack.

### Route53 record

-  optional
-  parameterized
-  enables inlining by consming VPC output HostedZoneId 

### Standard extensions

Rather then depending on VPC component for helper methods, they are extracted into "standard extensions" (stdext). https://github.com/toshke/hl-component-stdext . Standard extensions component name is parameterized. 

